### PR TITLE
fix: cover vercel config  node version with 20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "prettier-plugin-astro": "^0.14.0",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwindcss": "^3.4.4"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }


### PR DESCRIPTION
vercel setting default node version 22.x